### PR TITLE
Add option to use file name column in meta data.

### DIFF
--- a/resources/config/default/standard.properties
+++ b/resources/config/default/standard.properties
@@ -54,6 +54,7 @@ mail.to=msioda@uncc.edu
 metadata.barcodeColumn=BarcodeSequence
 metadata.columnDelim=\t
 #metadata.commentChar=
+#metadata.fileNameColumn=
 #metadata.filePath=
 metadata.nullValue=NA
 metadata.required=Y

--- a/src/biolockj/module/implicit/ImportMetadata.java
+++ b/src/biolockj/module/implicit/ImportMetadata.java
@@ -88,6 +88,15 @@ public class ImportMetadata extends BioModuleImpl implements BioModule
 		}
 		else
 		{
+			if( ModuleUtil.moduleExists( Demultiplexer.class.getName() ) )
+			{
+				MetaUtil.removeColumn( Config.getString( MetaUtil.META_FILENAME_COLUMN ), getTempDir() );
+				Log.warn( ImportMetadata.class,
+						"The " + MetaUtil.META_FILENAME_COLUMN
+								+ " option is incompatible with using the demultiplexer module. The supplied value \""
+								+ Config.getString( MetaUtil.META_FILENAME_COLUMN ) + "\" will be ignored." );
+				Config.setConfigProperty( MetaUtil.META_FILENAME_COLUMN, "" );
+			}
 			Log.info( getClass(),
 					"Importing metadata (column delim=" + Config.requireString( MetaUtil.META_COLUMN_DELIM ) + "): "
 							+ MetaUtil.getFile().getAbsolutePath() );

--- a/src/biolockj/util/MetaUtil.java
+++ b/src/biolockj/util/MetaUtil.java
@@ -340,6 +340,32 @@ public class MetaUtil
 			setFile( MetaUtil.getMetadata() );
 			refreshCache();
 		}
+
+		// verify that values in columns used as identifiers are unique per sample.
+		// checkUniqueVals( META_BARCODE_COLUMN );
+		checkUniqueVals( META_FILENAME_COLUMN );
+
+	}
+
+	/**
+	 * Verify that a column in the metadata is unique for each sample
+	 * 
+	 * @param columnAttr {@link biolockj.Config} property giving the name of the column.
+	 * @throws Exception if number of unique values in the column does not match number of samples
+	 */
+	private static void checkUniqueVals( String columnAttr ) throws Exception
+	{
+		final String columnName = Config.getString( columnAttr );
+		if( columnName != null && !columnName.isEmpty() )
+		{
+			int lenSamples = ( new HashSet<String>( getSampleIds() ) ).size();
+			int lenVals = ( new HashSet<String>( getFieldValues( columnName ) ) ).size(); // get unique values
+			if( lenSamples != lenVals )
+			{
+				throw new Exception( "Should have exactly 1 unique value per sample in column " + columnName
+						+ ". Found " + lenVals + " unique values for " + lenSamples + " samples." );
+			}
+		}
 	}
 
 	/**
@@ -562,6 +588,11 @@ public class MetaUtil
 	 * {@link biolockj.Config} property {@value #META_BARCODE_COLUMN} defines metadata column with identifying barcode
 	 */
 	public static final String META_BARCODE_COLUMN = "metadata.barcodeColumn";
+
+	/**
+	 * {@link biolockj.Config} property {@value #META_FILENAME_COLUMN} defines metadata column with input file names
+	 */
+	public static final String META_FILENAME_COLUMN = "metadata.fileNameColumn";
 
 	/**
 	 * {@link biolockj.Config} property that defines how metadata columns are separated: {@value #META_COLUMN_DELIM}

--- a/src/biolockj/util/RMetaUtil.java
+++ b/src/biolockj/util/RMetaUtil.java
@@ -114,6 +114,10 @@ public final class RMetaUtil
 			{
 				rScriptFields.remove( Config.getString( MetaUtil.META_BARCODE_COLUMN ) );
 			}
+			if( Config.getString( MetaUtil.META_FILENAME_COLUMN ) != null )
+			{
+				rScriptFields.remove( Config.getString( MetaUtil.META_FILENAME_COLUMN ) );
+			}
 
 			// remove BLJ generated fields since inclusion depends upon the report.num* properties
 			rScriptFields.remove( ParserModuleImpl.NUM_HITS );


### PR DESCRIPTION
 * Add option to use file name column in meta data, rather than using trimPrefix/Suffix to extract sample id.
 * Add validation method for unique values in metadata columns.
 * Warn about incompatible options.