### PR TITLE
Save and load projects from local disk, get module info from Java Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ BioLockJ.jar
 .project
 *_not4git*
 .Rproj.user
+.Rhistory

--- a/web_app/Dockerfile
+++ b/web_app/Dockerfile
@@ -3,6 +3,24 @@ FROM biolockj/webapp
 RUN rm -r $BLJ/web_app/*
 COPY . $BLJ/web_app/
 ENV PROJECT_DIRS=$BLJ/web_app
+
+# Add AWS
+ARG DEBIAN_FRONTEND=noninteractive
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get update && apt-get install -y \
+ python-dev \
+ python-pip \
+ python-tk
+# install AWS CLI
+RUN pip install awscli --upgrade
+RUN aws --version
+
+# Add git
+RUN apt-get update && \
+  apt-get install -y git \
+  curl \
+  vim
+
 #RUN rm /package.json
 #RUN rm /app.js
 #if the new BLJ webapp doesn't pull the latest webapp, run these
@@ -10,3 +28,6 @@ ENV PROJECT_DIRS=$BLJ/web_app
 # if mike updates his:
 # docker pull biolockj/webapp && docker build --tag amyerke/webapp .
 WORKDIR $BLJ/web_app/
+
+# Install Malcolm's repo
+#git clone https://github.com/mjzapata/AWSBatchGenomicsStack

--- a/web_app/lib/indexAux.js
+++ b/web_app/lib/indexAux.js
@@ -6,7 +6,6 @@
 var fs = require('fs'),
   path = require('path');
 
-
 /**parseBljJson turns a config json into a string in flat file format.*/
 exports.formatAsFlatFile = function(modules, paramKeys, paramValues){
   var text = "";
@@ -28,10 +27,7 @@ exports.formatAsFlatFile = function(modules, paramKeys, paramValues){
     return text;
   } catch (e) {
     console.log(e);
-  } finally {
-
   }
-
 };
 
 exports.progressStatus = function(dirPath){
@@ -57,32 +53,6 @@ exports.saveConfigToLocal = function(configName, configText){
   })
 }
 
-exports.buildPartialLaunchArgument = function (validConfig, restart = false){
-  /**
-  Returns something like:
-  inputDirPaths: "/Users/aaronyerke/git/blj_support/resources/test/data/multiplexed/combinedFastq"
-  metadataFilePath: "/Users/aaronyerke/git/blj_support/resources/test/metadata/testMetadata.tsv"
-  trimPrimersFilePath: "/Users/aaronyerke/git/blj_support/resources/test/primers/testPrimers.txt"
-  */
-  partialLauchArgument = {};
-  //config key : blj_argument
-  //config Path will be built serverside
-  const runtimeArguments = {
-    'input.dirPaths' : 'inputDirPaths',
-    'metadata.filePath' : 'metadataFilePath',
-    'trimPrimers.filePath' : 'trimPrimersFilePath'
-    //'project.configFile' : 'CONFIG_PATH',
-    // TODO: Add -r and -p to arguements list
-  };
-  Object.keys(runtimeArguments).forEach(key => {
-    if (Object.keys(validConfig).includes(key)){
-      partialLauchArgument[runtimeArguments[key].toString()] = validConfig[key];
-    };
-  })
-  console.log('partialLaunchArgument: ', partialLaunchArgument);
-  return partialLauchArgument;
-}
-
 exports.createFullLaunchCommand = function(launchJSON, restartPath){//
   //const bljProjDir = process.env.BLJ_PROJ; //path to blj_proj
   //const bljDir = process.env.BLJ;
@@ -101,7 +71,7 @@ exports.createFullLaunchCommand = function(launchJSON, restartPath){//
   command.push('-docker');
   if (restartPath !== undefined ){
     //note, change to make more universal
-    command.push(`-r ${restartPath}`)
+    command.push(`-r ${restartPath}`);
   }
   console.log('launch');
   console.log('full launch command: \n', command);

--- a/web_app/public/javascripts/config_config.js
+++ b/web_app/public/javascripts/config_config.js
@@ -633,56 +633,12 @@ for (const launch of document.getElementsByClassName("openLaunchModal")) {
 
           })
         });
-
-      // var request = new XMLHttpRequest();
-      // request.open('POST', '/checkProjectExists', true);
-      // request.setRequestHeader("Content-Type", "application/json");
-      // request.send(JSON.stringify({
-      //   projectName : currentConfig.paramValues[currentConfig.paramKeys.indexOf('project.configFile')]
-      //   //additional parameters for launch
-      // }));
-      //   request.onreadystatechange = function() {
-        // if (request.readyState == XMLHttpRequest.DONE) {
-        //   console.log(request.responseText);
-        //   if (request.responseText !== ''){
-        //     const checkedParams = JSON.parse(request.responseText);
-        //     console.log('checkedParams: ', checkedParams);
-        //     currentConfig.prevProjectName = checkedParams.projectName;
-        //     currentConfig.prevProjectPath = checkedParams.projectPath;
-        //     const rOrEText = document.getElementById('restartOrEraseText');
-        //     rOrEText.innerHTML = `Your current project, ${currentConfig.prevProjectName}, has the same name as a previous project.  Would you like to restart the pipeline or erase the old one and rerun from your new configuration file? (Click only once)`;
-        //     const rOrE = document.getElementById('restartOrErase');
-        //     if (rOrE.classList.contains('hidden')){
-        //       rOrE.classList.remove('hidden');
-        //       }
-        //     const restartProject = document.getElementById('restartProject');
-        //     restartProject.addEventListener('click', function(){
-        //       console.log('inrestart event');
-        //       console.log(this);
-        //       launcher(launchAction = 'restartProject', restartProjectPath = currentConfig.prevProjectPath);
-        //     });
-        //     const eraseRestart = document.getElementById('eraseRestart');
-        //     eraseRestart.addEventListener('click', function(){
-        //       console.log('launching erarse terstart ', currentConfig.prevProjectPath);
-        //       launcher(launchAction = 'eraseRestart', projectNameToDelete = currentConfig.prevProjectPath)
-        //     })
-        //   }else{
-        //     document.getElementById('launchBlj').classList.remove('hidden');
-        //   }
-        //   }
-        // }
       }
     } catch (e) {
       alert(e)
     }
   });//end eventlistener
 };//end forloop
-
-// const launchBlj = document.getElementById('launchBlj');
-// launchBlj.addEventListener("click", function(event){
-//   event.preventDefault();
-//   launcher();
-// });
 
 //for autosave
 const configFormInputs = Array.from(document.getElementById('configForm').getElementsByTagName('input'));
@@ -957,6 +913,7 @@ function retreiveDefaultProps(dpropPath) {
 document.getElementById('submitAWS').addEventListener('click', function(evt){
   evt.preventDefault();
   let formData = {};
+  console.log(document.getElementById('AwsForm'));
   let AwsForm = new FormData(document.getElementById('AwsForm'));
   for (var i of AwsForm.entries()) {
     console.log(i);

--- a/web_app/public/javascripts/config_config.js
+++ b/web_app/public/javascripts/config_config.js
@@ -23,7 +23,13 @@ function Config(modules = [], paramKeys = [], paramValues = [], comments = []){
       console.dir(this);
 
       //set items in local storage
-      localStorage.setItem(file.name, JSON.stringify(this));
+      //localStorage.setItem(file.name, JSON.stringify(this));
+
+      saveConfigToGui({
+          configName : file.name,
+          configText : this.formatAsFlatFile(),
+      });
+
 
       //hide used file reader from user
       document.getElementById("openConfig").style.display = "none";
@@ -35,68 +41,72 @@ function Config(modules = [], paramKeys = [], paramValues = [], comments = []){
   }//end load localhost
 
   this.sendConfigDataToForms = function(){
-    if (this.paramKeys.length != this.paramValues.length){
-      alert('Your paramKeys should be the same length as your paramValues.  Find the error');
-      return false;
-    }
-    //reorder module list elements to match the config
-    myModules = orderModulesFromLocalFiles(this.modules, myModules);
-    runModuleFunctions();
-
-    //get all input elements for adding values too
-    const selects = Array.from(document.getElementsByTagName('select'));
-    const inputs = Array.from(document.getElementsByTagName('input'));
-    const texts = inputs.filter(inp => inp.type === 'text');
-    const radios = inputs.filter(inp => inp.type === 'radio');
-    const checkboxs = inputs.filter(inp => inp.type === 'checkbox');
-    const numbers = inputs.filter(inp => inp.type === 'number');
-
-    //first step, loop through modules and show them
-    for (mod of this.modules){
-      var domModule = document.getElementById('module');
-      var domModuleLi = domModule.getElementsByTagName('li');
-      for (var b = 0; b < domModuleLi.length; b++) {//for mod in mod li
-        if (mod == domModuleLi[b].innerHTML) {
-          try{
-          domModuleLi[b].click();//add('modChoosen');
-          }catch(err) {
-            alert(err);
-          }finally{
-            }
-        };//end if
-      };//end for-loop over domModuleLi
-    }//end this.modules for loop
-
-    //Add parameter values to page inputs
-    for (let i = 0; i < this.paramKeys.length; i++) {
-      const key = this.paramKeys[i];
-      const valueOfKey = this.paramValues[i];
-      try {
-        if (checkboxs.map(check => check.name).includes(key)){
-          const checkTargets = checkboxs.filter(check => check.name == key);
-          const cachedChecks = valueOfKey.split(',');
-          cachedChecks.forEach(val => {
-            checkTargets.find(check => check.value === val).checked = true;
-          });
-        }else{
-          var targetInput = document.getElementById(key);
-          if (targetInput.tagName == 'SELECT'){
-            //console.log(targetInput);
-            var select = selects.find(sel => sel.id == key);
-            var opt =
-            Array.apply(null, select.options).find(option => option.value === valueOfKey);
-            if (opt.value != undefined){ opt.setAttribute('selected', true); };//select opt if not undefined
-            }
-          else if (targetInput.type == 'text' || targetInput.type == 'number'){
-            targetInput.value = valueOfKey;
-            }
-          }//end else
-        document.getElementById("mainMenu").style.display = "block";
-      } catch (err) {
-        alert(err + "\n problem with " + key + ".")
-      } finally{
+    console.log('in currentConfig.sendConfigDataToForms()');
+    try {
+      if (this.paramKeys.length != this.paramValues.length){
+        alert('Your paramKeys should be the same length as your paramValues.  Find the error');
+        return false;
       }
-    }; //end for-loop over keys/parameters
+      //reorder module list elements to match the config
+      myModules = orderModulesFromLocalFiles(this.modules, myModules);
+      runModuleFunctions();
+
+      //get all input elements for adding values too
+      const selects = Array.from(document.getElementsByTagName('select'));
+      const inputs = Array.from(document.getElementsByTagName('input'));
+      const texts = inputs.filter(inp => inp.type === 'text');
+      const radios = inputs.filter(inp => inp.type === 'radio');
+      const checkboxs = inputs.filter(inp => inp.type === 'checkbox');
+      const numbers = inputs.filter(inp => inp.type === 'number');
+
+      //first step, loop through modules and show them
+      for (mod of this.modules){
+        var domModule = document.getElementById('module');
+        var domModuleLi = domModule.getElementsByTagName('li');
+        for (var b = 0; b < domModuleLi.length; b++) {//for mod in mod li
+          if (mod == domModuleLi[b].innerHTML) {
+            try{
+            domModuleLi[b].click();//add('modChoosen');
+            }catch(err) {
+              alert(err);
+            }finally{
+              }
+          };//end if
+        };//end for-loop over domModuleLi
+      }//end this.modules for loop
+
+      //Add parameter values to page inputs
+      for (let i = 0; i < this.paramKeys.length; i++) {
+        const key = this.paramKeys[i];
+        const valueOfKey = this.paramValues[i];
+        try {
+          if (checkboxs.map(check => check.name).includes(key)){
+            const checkTargets = checkboxs.filter(check => check.name == key);
+            const cachedChecks = valueOfKey.split(',');
+            cachedChecks.forEach(val => {
+              checkTargets.find(check => check.value === val).checked = true;
+            });
+          }else{
+            var targetInput = document.getElementById(key);
+            if (targetInput.tagName == 'SELECT'){
+              var select = selects.find(sel => sel.id == key);
+              var opt =
+              Array.apply(null, select.options).find(option => option.value === valueOfKey);
+              if (opt.value != undefined){ opt.setAttribute('selected', true); };//select opt if not undefined
+              }
+            else if (targetInput.type == 'text' || targetInput.type == 'number'){
+              targetInput.value = valueOfKey;
+              }
+            }//end else
+          document.getElementById("mainMenu").style.display = "block";
+        } catch (err) {
+          alert(err + "\n problem with " + key + ".")
+        }
+      }; //end for-loop over keys/parameters
+    } catch (e) {
+      console.error(e);
+    }
+
   }//end this.sendConfigDataToForms
 
   this.saveConfigParamsForm = function (){
@@ -126,7 +136,17 @@ function Config(modules = [], paramKeys = [], paramValues = [], comments = []){
     };
     _this.modulesToCurrentConfig();
     console.log('configFile.value', configFile.value);
-    localStorage.setItem(configFile.value, JSON.stringify(_this));
+    console.log(JSON.stringify({
+        configName : configFile.value,
+        configText : _this.formatAsFlatFile(),
+    }));
+    //var save = saveConfigToGui({test : "test"});
+    saveConfigToGui({
+        configName : configFile.value,
+        configText : _this.formatAsFlatFile(),
+    });
+    // localStorage.setItem(configFile.value, JSON.stringify(_this));
+
     console.log('saved');
     console.dir(_this);
   };//end this.saveConfigParams
@@ -140,7 +160,11 @@ function Config(modules = [], paramKeys = [], paramValues = [], comments = []){
       };
     };
     console.log("this.paramKeys.indexOf('project.configFile'): ", this.paramKeys.indexOf('project.configFile'));
-    localStorage.setItem(this.paramValues[this.paramKeys.indexOf('project.configFile')], JSON.stringify(this));
+    saveConfigToGui({
+        configName : this.paramValues[this.paramKeys.indexOf('project.configFile')],
+        configText : this.formatAsFlatFile(),
+    });
+    //localStorage.setItem(this.paramValues[this.paramKeys.indexOf('project.configFile')], JSON.stringify(this));
   };//end modulesToCurrentConfig
 
   this.validateConfig = function() {
@@ -513,25 +537,34 @@ document.getElementById('localFile').addEventListener('change', currentConfig.lo
 //Adding all eventlisteners
 //eventlistener for adding the recent config files to "recent"
 document.getElementById("recent").addEventListener("mouseover", function() {
-  const recentMenuChoices = Object.keys(localStorage);
-  for (var i = 0; i < recentMenuChoices.length; i++) {
-    let opt = document.createElement('a');
-    opt.setAttribute("name", recentMenuChoices[i]);
-    var text = document.createTextNode(recentMenuChoices[i].toString());
-    opt.addEventListener("click", function() {
-     const tempConfig = JSON.parse(localStorage.getItem(this.name));
-      console.log(tempConfig);
-      currentConfig = new Config(tempConfig.modules, tempConfig.paramKeys, tempConfig.paramValues);
-      currentConfig.sendConfigDataToForms();
-      console.log(currentConfig);
-    });
-    opt.appendChild(text);
-    opt.setAttribute('position', 'relative');
-    opt.setAttribute('display', 'block');
-    opt.classList.add('recentConfigs');
-    let proj = document.getElementById("projects");
-    proj.appendChild(opt);
-  };
+    const configs = retrieveConfigs();
+    configs.then(retrievedConfigs => {
+      console.log(retrievedConfigs);
+      for (var i = 0; i < retrievedConfigs.length; i++) {
+        let opt = document.createElement('a');
+        opt.setAttribute("name", retrievedConfigs[i]);
+        var text = document.createTextNode(retrievedConfigs[i].toString());
+        opt.addEventListener("click", function() {
+          console.log(JSON.stringify({propertiesFile : this.name}))
+          const tempConfig = retrievePropertiesFile({propertiesFile : this.name.concat('.properties')});
+          tempConfig.then( propertiesFile => {
+            console.log(propertiesFile);
+            currentConfig = new Config();
+            currentConfig.loadFromText(propertiesFile.data);
+            currentConfig.paramKeys.push('project.configFile');
+            currentConfig.paramValues.push(this.name);
+            currentConfig.sendConfigDataToForms();
+            console.log(currentConfig);
+          })
+        });
+        opt.appendChild(text);
+        opt.setAttribute('position', 'relative');
+        opt.setAttribute('display', 'block');
+        opt.classList.add('recentConfigs');
+        let proj = document.getElementById("projects");
+        proj.appendChild(opt);
+    };
+  })
 }, {
  once: true
 });
@@ -561,45 +594,83 @@ for (const launch of document.getElementsByClassName("openLaunchModal")) {
       if ( currentConfig.validateConfig() === true ){
       launchModal.style.display = "block";
 
-      var request = new XMLHttpRequest();
-      request.open('POST', '/checkProjectExists', true);
-      request.setRequestHeader("Content-Type", "application/json");
-      request.send(JSON.stringify({
-        projectName : currentConfig.paramValues[currentConfig.paramKeys.indexOf('project.configFile')]
-        //additional parameters for launch
-      }));
-        console.log('check request sent');
-        request.onreadystatechange = function() {
-          console.log('this.status: ', this.status);
-        if (request.readyState == XMLHttpRequest.DONE) {
-          console.log(request.responseText);
-          if (request.responseText !== ''){
-            const checkedParams = JSON.parse(request.responseText);
-            console.log('checkedParams: ', checkedParams);
-            currentConfig.prevProjectName = checkedParams.projectName;
-            currentConfig.prevProjectPath = checkedParams.projectPath;
-            const rOrEText = document.getElementById('restartOrEraseText');
-            rOrEText.innerHTML = `Your current project, ${currentConfig.prevProjectName}, has the same name as a previous project.  Would you like to restart the pipeline or erase the old one and rerun from your new configuration file? (Click only once)`;
-            const rOrE = document.getElementById('restartOrErase');
-            if (rOrE.classList.contains('hidden')){
-              rOrE.classList.remove('hidden');
-              }
-            const restartProject = document.getElementById('restartProject');
-            restartProject.addEventListener('click', function(){
-              console.log('inrestart event');
-              console.log(this);
-              launcher(launchAction = 'restartProject', restartProjectPath = currentConfig.prevProjectPath);
-            });
-            const eraseRestart = document.getElementById('eraseRestart');
-            eraseRestart.addEventListener('click', function(){
-              console.log('launching erarse terstart ', currentConfig.prevProjectPath);
-              launcher(launchAction = 'eraseRestart', projectNameToDelete = currentConfig.prevProjectPath)
-            })
-          }else{
-            document.getElementById('launchBlj').classList.remove('hidden');
+        const projectFolderNames = retrieveProjects();
+        projectFolderNames.then((projNames) => {
+
+          //erase old restart options
+          const optionalProj = document.getElementById('projOptFieldSet');
+          optionalProj.innerHTML = '';
+
+          //add line
+          let hr = document.createElement('hr');
+          //l.innerHTML = 'Current Projects';
+          optionalProj.appendChild(hr);
+
+          //get all projects as options for restart
+          for (var i = 0; i < projNames.length; i++) {
+            let newRadio = document.createElement('input');
+            newRadio.setAttribute('type', 'radio');
+            newRadio.setAttribute('name', 'projLaunch');
+            newRadio.setAttribute('value', projNames[i]);
+            newRadio.setAttribute('name', 'projLaunch');
+            newRadio.setAttribute('class', 'projLaunch');
+            let newP = document.createElement('p');
+            newP.innerHTML = `Use this configuration to restart ${projNames[i]}`;
+            newP.appendChild(newRadio);
+            optionalProj.appendChild(newP);
           }
-          }
-        }
+
+          const projLaunchOptionsForm = document.getElementById('projectLaunchOptions');
+
+          document.getElementById('launchBlj').addEventListener('click', function(){
+            const projRadios = projLaunchOptionsForm.elements['projLaunch'];
+            const launchAction = projLaunchOptionsForm.elements['restartOption']
+            if (projRadios.value === 'launchNew'){
+              launcher(projRadios.value);
+            }else{
+              launcher(launchAction.value, projRadios.value)
+            }
+
+          })
+        });
+
+      // var request = new XMLHttpRequest();
+      // request.open('POST', '/checkProjectExists', true);
+      // request.setRequestHeader("Content-Type", "application/json");
+      // request.send(JSON.stringify({
+      //   projectName : currentConfig.paramValues[currentConfig.paramKeys.indexOf('project.configFile')]
+      //   //additional parameters for launch
+      // }));
+      //   request.onreadystatechange = function() {
+        // if (request.readyState == XMLHttpRequest.DONE) {
+        //   console.log(request.responseText);
+        //   if (request.responseText !== ''){
+        //     const checkedParams = JSON.parse(request.responseText);
+        //     console.log('checkedParams: ', checkedParams);
+        //     currentConfig.prevProjectName = checkedParams.projectName;
+        //     currentConfig.prevProjectPath = checkedParams.projectPath;
+        //     const rOrEText = document.getElementById('restartOrEraseText');
+        //     rOrEText.innerHTML = `Your current project, ${currentConfig.prevProjectName}, has the same name as a previous project.  Would you like to restart the pipeline or erase the old one and rerun from your new configuration file? (Click only once)`;
+        //     const rOrE = document.getElementById('restartOrErase');
+        //     if (rOrE.classList.contains('hidden')){
+        //       rOrE.classList.remove('hidden');
+        //       }
+        //     const restartProject = document.getElementById('restartProject');
+        //     restartProject.addEventListener('click', function(){
+        //       console.log('inrestart event');
+        //       console.log(this);
+        //       launcher(launchAction = 'restartProject', restartProjectPath = currentConfig.prevProjectPath);
+        //     });
+        //     const eraseRestart = document.getElementById('eraseRestart');
+        //     eraseRestart.addEventListener('click', function(){
+        //       console.log('launching erarse terstart ', currentConfig.prevProjectPath);
+        //       launcher(launchAction = 'eraseRestart', projectNameToDelete = currentConfig.prevProjectPath)
+        //     })
+        //   }else{
+        //     document.getElementById('launchBlj').classList.remove('hidden');
+        //   }
+        //   }
+        // }
       }
     } catch (e) {
       alert(e)
@@ -607,11 +678,11 @@ for (const launch of document.getElementsByClassName("openLaunchModal")) {
   });//end eventlistener
 };//end forloop
 
-const launchBlj = document.getElementById('launchBlj');
-launchBlj.addEventListener("click", function(event){
-  event.preventDefault();
-  launcher();
-});
+// const launchBlj = document.getElementById('launchBlj');
+// launchBlj.addEventListener("click", function(event){
+//   event.preventDefault();
+//   launcher();
+// });
 
 //for autosave
 const configFormInputs = Array.from(document.getElementById('configForm').getElementsByTagName('input'));
@@ -811,52 +882,52 @@ function tableToCurrentConfig(){
   console.log('paramKeys len: ', paramKeys.length);
   currentConfig.paramKeys = paramKeys;
   currentConfig.paramValues = paramValues;
-  alert(currentConfig.paramKeys.length);
+  //alert(currentConfig.paramKeys.length);
   currentConfig.sendConfigDataToForms();
   currentConfig.saveConfigParamsForm();
   table.classList.add('hidden');
 }//function tableToCurrentConfig...
 
-//retrieves chain of default props without user input, not used anymore
-// function resolveDefaultProps(config, docker = false){
-//   const dpropPath = config.paramValues[config.paramKeys.indexOf('project.defaultProps')];
-//   console.log('dpropPath ', dpropPath);
-//   // if (!config.paramKeys.includes('project.defaultProps')){
-//   //   console.error('no default props found');
-//   //   return;
-//   // }
-//   const defaultConfig = new Config();
-//   const dprop = retreiveDefaultProps(dpropPath, docker);
-//   dprop.then( retreived => {
-//     defaultConfig.loadFromText( retreived );
-//     console.log('defaultConfig ', defaultConfig);
-//     const defaultConfigDPath = defaultConfig.paramValues[defaultConfig.paramKeys.indexOf('project.defaultProps')];
-//     console.log('dpropPat ',dpropPath);
-//     console.log('defaultConfigDPat ',defaultConfigDPath);
-//     if (defaultConfigDPath && defaultConfigDPath !== dpropPath){
-//       console.log('need to resolve again');
-//       return resolveDefaultProps(defaultConfig);
-//     }
-//     for (let i = 0; i < defaultConfig.paramKeys.length; i++) {
-//       const dfKey = defaultConfig.paramKeys[i]
-//       if (dfKey !== 'project.configFile' && !config.paramKeys.includes(dfKey)){
-//         config.paramKeys.push(defaultConfig.paramKeys[i]);
-//         config.paramValues.push(defaultConfig.paramValues[i])
-//       }
-//     }
-//     return config;
-//   });
-// }
+// retrieves chain of default props without user input, not used anymore
+function resolveDefaultProps(config, docker = false){
+  const dpropPath = config.paramValues[config.paramKeys.indexOf('project.defaultProps')];
+  console.log('dpropPath ', dpropPath);
+  // if (!config.paramKeys.includes('project.defaultProps')){
+  //   console.error('no default props found');
+  //   return;
+  // }
+  const defaultConfig = new Config();
+  const dprop = retreiveDefaultProps(dpropPath, docker);
+  dprop.then( retreived => {
+    defaultConfig.loadFromText( retreived );
+    console.log('defaultConfig ', defaultConfig);
+    const defaultConfigDPath = defaultConfig.paramValues[defaultConfig.paramKeys.indexOf('project.defaultProps')];
+    console.log('dpropPat ',dpropPath);
+    console.log('defaultConfigDPat ',defaultConfigDPath);
+    if (defaultConfigDPath && defaultConfigDPath !== dpropPath){
+      console.log('need to resolve again');
+      return resolveDefaultProps(defaultConfig);
+    }
+    for (let i = 0; i < defaultConfig.paramKeys.length; i++) {
+      const dfKey = defaultConfig.paramKeys[i]
+      if (dfKey !== 'project.configFile' && !config.paramKeys.includes(dfKey)){
+        config.paramKeys.push(defaultConfig.paramKeys[i]);
+        config.paramValues.push(defaultConfig.paramValues[i])
+      }
+    }
+    return config;
+  });
+}
 
 //returns config flat file
-function retreiveDefaultProps(dpropPath, docker = false) {
+function retreiveDefaultProps(dpropPath) {
   return new Promise((resolve, reject) => {
     const request = new XMLHttpRequest();
     request.open('POST', '/defaultproperties', true);
     request.setRequestHeader("Content-Type", "application/json");
     request.send(JSON.stringify({
       file : dpropPath,
-      docker : docker,// can get rid of this
+      //docker : docker,// can get rid of this
       //additional parameters for launch
     }));
     request.onreadystatechange = function() {
@@ -883,6 +954,40 @@ function retreiveDefaultProps(dpropPath, docker = false) {
 //         launchModal.style.display = "none";
 //     }
 // }
+document.getElementById('submitAWS').addEventListener('click', function(evt){
+  evt.preventDefault();
+  let formData = {};
+  let AwsForm = new FormData(document.getElementById('AwsForm'));
+  for (var i of AwsForm.entries()) {
+    console.log(i);
+    formData[i[0]] = i[1];
+  }
+  var request = new XMLHttpRequest();
+  request.open('POST', '/startAws', true);
+  request.setRequestHeader("Content-Type", "application/json");
+  request.send(JSON.stringify({formData}));
+    request.onreadystatechange = function() {
+    if (request.readyState == XMLHttpRequest.DONE) {
+      console.log(request.responseText);
+    }
+  }
+})//document.getElementById('submitAWS')
+
+
+document.getElementById('project.env').addEventListener('click', function(evt){
+  const AwsButton = document.getElementById('AwsButton');
+  switch (this.value) {
+    case 'aws':
+      AwsButton.classList.remove('hidden');
+      AwsButton.click();
+      break;
+    default:
+      AwsButton.classList.add('hidden');
+  }
+});
+
+
+
 if(typeof(EventSource) !== "undefined") {
 	console.log('EventSource Works');
 		// Yes! Server-sent events support!
@@ -902,7 +1007,6 @@ if(typeof(EventSource) !== "undefined") {
 	StreamLog.onmessage = function(event) {
 		document.getElementById("log").innerHTML += event.data + "<br>";
 	};
-
 	//for getting progress from blj
 	var streamProgress = new EventSource("/streamProgress",{ withCredentials: true });
 	streamProgress.addEventListener("message", function(e) {
@@ -944,10 +1048,10 @@ if(typeof(EventSource) !== "undefined") {
     // Sorry! No server-sent events support..
 }
 
-function launcher(launchAction = 'launch', restartProjectPath, projectNameToDelete){
+function launcher(launchAction = 'launchNew', restartProjectPath){
   event.preventDefault();
   //launchModal.style.display = "block";
-  requestParams = {
+  let requestParams = {
     modules : currentConfig.modules,
     paramKeys : currentConfig.paramKeys,
     paramValues : currentConfig.paramValues,
@@ -955,13 +1059,14 @@ function launcher(launchAction = 'launch', restartProjectPath, projectNameToDele
     launchAction : launchAction,
     //additional parameters for launch
   }
-  if (launchAction === 'restartProject' || launchAction === 'eraseRestart' ){
+  if (launchAction === 'restartFromCheckPoint' || launchAction === 'eraseThenRestart' ){
     requestParams['restartProjectPath'] = restartProjectPath;
     console.log(requestParams);
-  }else if (launchAction === 'eraseRestart') {
-    requestParams['projectNameToDelete'] = projectNameToDelete;
-    console.log(requestParams);
   }
+  // else if (launchAction === 'eraseThenRestart') {
+  //   requestParams['projectNameToDelete'] = projectNameToDelete;
+  //   console.log(requestParams);
+  // }
 
   var request = new XMLHttpRequest();
   request.open('POST', '/launch', true);
@@ -978,3 +1083,5 @@ function launcher(launchAction = 'launch', restartProjectPath, projectNameToDele
   }
   console.log(request.responseText);
 }
+
+

--- a/web_app/public/javascripts/layout.js
+++ b/web_app/public/javascripts/layout.js
@@ -1,0 +1,65 @@
+function saveConfigToGui(configTextandNameObject){
+  var request = new XMLHttpRequest();
+  request.open('POST', '/saveConfigToGui', true);
+  request.setRequestHeader("Content-Type", "application/json");
+  request.send(JSON.stringify(
+    configTextandNameObject
+  ));
+  console.log('launch sent');
+  request.onreadystatechange = function() {
+  if (request.readyState == XMLHttpRequest.DONE) {
+    console.log(request.responseText);
+    //window.location = '/progress';
+    }
+  }
+  //return returnPromiseFromServer('/saveConfigToGui', requestParameter = configTextandNameObject);
+}
+
+function retrieveProjects(){//gets all project names
+  return returnPromiseFromServer('/retrieveProjects', requestParameter = null);
+}//end function retrieveProjects
+
+function retrieveConfigs(){
+  return returnPromiseFromServer('/retrieveConfigs', requestParameter = null);
+}//end function retrieveProjects
+
+function retrievePropertiesFile(configName){
+  console.log(configName);
+  return returnPromiseFromServer('/retrievePropertiesFile', requestParameter = configName);
+}
+
+// function retreiveDefaultProps(dpropPath){
+//   returnPromiseFromServer('/defaultproperties', requestParameter = dpropPath)
+// }
+
+function returnPromiseFromServer(address, requestParameter, method = 'POST'){
+  return new Promise((resolve, reject) => {
+    var request = new XMLHttpRequest();
+    request.open(method, address, true);
+    request.setRequestHeader("Content-Type", "application/json");
+    request.onload = function() {
+      try{
+        if(this.status === 200 && request.readyState === 4){
+          resolve(JSON.parse(this.responseText));
+        }else{
+          reject(this.status + " " + this.statusText)
+        }
+      } catch(e) {
+        reject (e.message);
+      }
+    };
+    request.onerror = function() {
+      reject(this.status + " " + this.statusText)
+    };
+    try {
+      if (requestParameter) {
+        request.send(JSON.stringify(requestParameter));
+      }
+      else {
+        request.send();
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  })
+}

--- a/web_app/public/javascripts/splash.js
+++ b/web_app/public/javascripts/splash.js
@@ -1,0 +1,95 @@
+var projectsViewer = document.getElementById('projectsViewer');
+
+var handleBarsTest = {test : 'testing handlebars'}
+
+var projects = retrieveProjects();
+projects.then(proj => {
+  console.log(proj);
+  distributeIcons(projectsViewer, proj)
+});
+
+function distributeIcons(containerDiv, iconFileNames){
+  console.log(iconFileNames);
+  console.log(containerDiv);
+  for (var i = 0; i < iconFileNames.length; i++) {
+    const spn = document.createElement('span');
+    spn.classList.add('projectIcon');
+    spn.innerHTML = iconFileNames[i];
+
+    const selecter = document.createElement('SELECT');
+    const opt1 = document.createElement('option');
+    const opt2 = document.createElement('option');
+    opt1.innerHTML = 'View interactive visualization 1';
+    opt2.innerHTML = 'View interactive visualization 2';
+
+    selecter.appendChild(opt1);
+    selecter.appendChild(opt2);
+    spn.appendChild(selecter);
+    containerDiv.appendChild(spn);
+  }
+};
+function saveConfigToGui(configTextandNameObject){
+  var request = new XMLHttpRequest();
+  request.open('POST', '/saveConfigToGui', true);
+  request.setRequestHeader("Content-Type", "application/json");
+  request.send(JSON.stringify(
+    configTextandNameObject
+  ));
+  console.log('launch sent');
+  request.onreadystatechange = function() {
+  if (request.readyState == XMLHttpRequest.DONE) {
+    console.log(request.responseText);
+    //window.location = '/progress';
+    }
+  }
+  //return returnPromiseFromServer('/saveConfigToGui', requestParameter = configTextandNameObject);
+}
+
+function retrieveProjects(){
+  return returnPromiseFromServer('/retrieveProjects', requestParameter = null);
+}//end function retrieveProjects
+
+function retrieveConfigs(){
+  return returnPromiseFromServer('/retrieveConfigs', requestParameter = null);
+}//end function retrieveProjects
+
+function retrievePropertiesFile(configName){
+  console.log(configName);
+  return returnPromiseFromServer('/retrievePropertiesFile', requestParameter = configName);
+}
+
+// function retreiveDefaultProps(dpropPath){
+//   returnPromiseFromServer('/defaultproperties', requestParameter = dpropPath)
+// }
+
+function returnPromiseFromServer(address, requestParameter, method = 'POST'){
+  return new Promise((resolve, reject) => {
+    var request = new XMLHttpRequest();
+    request.open(method, address, true);
+    request.setRequestHeader("Content-Type", "application/json");
+    request.onload = function() {
+      try{
+        if(this.status === 200 && request.readyState === 4){
+          resolve(JSON.parse(this.responseText));
+        }else{
+          reject(this.status + " " + this.statusText)
+        }
+      } catch(e) {
+        reject (e.message);
+      }
+    };
+    request.onerror = function() {
+      reject(this.status + " " + this.statusText)
+    };
+    try {
+      if (requestParameter) {
+        request.send(JSON.stringify(requestParameter));
+      }
+      else {
+        request.send();
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  })
+}

--- a/web_app/public/stylesheets/splash.css
+++ b/web_app/public/stylesheets/splash.css
@@ -1,0 +1,36 @@
+body {
+  background-image: url('../images/BioLockJ_Block_green.svg');
+}
+
+
+
+.fileViewer {
+  padding: 14px 10px;
+  background-color: rgb(255,246,220);
+  border: 1px solid black;
+  margin: 10px 30px 20px 30px;
+  flex: auto;
+}
+.projectIcon {
+  background-image: url('../images/BioLockJ_Block_green.svg');
+  background-repeat: no-repeat;
+  /* background-attachment: inherit; */
+  /* background-position: center top; */
+  text-indent: 30px;
+  /* opacity: 0.9; */
+  height: 20px;
+  width: 20px;
+  padding:10px;
+  margin:5px;
+  display: block;
+  text-shadow:     -1px -1px 0 #ffffff,
+    1px -1px 0 #ffffff,
+    -1px 1px 0 #ffffff,
+    1px 1px 0 #ffffff;
+  position: relative;
+  left: 30px;
+  color: black;
+}
+
+
+

--- a/web_app/routes/index.js
+++ b/web_app/routes/index.js
@@ -29,61 +29,136 @@ router.get('/config', function(req, res, next) {
   res.render('config', { title: 'Configuration' });
 });
 
-// router.get('/javadocs', function(req, res, next) {
-//   res.sendFile(path.join(__dirname,'..','views','docs','index.html'), { title: 'BioLockJ JavaDocs' });
-// });
+router.post('/retrieveProjects', function(req, res, next) {
+  console.log('retrieveProjects');
+  try {
+    let projects = [];
+    fs.readdir(path.join('/', 'pipeline'), (err, files) => {
+      if (err) {
+        console.error(err);
+      }
+      files.forEach(file => {
+        console.log(file);
+        const checkFile = fs.lstatSync(path.join('/','pipeline',file));
+          if (checkFile.isDirectory()) {
+            console.log('file is dir');
+            projects.push(file);
+            // console.log(projects);
+          };
+        });
+        console.log(projects);
+        res.setHeader("Content-Type", "text/html");
+        res.write(JSON.stringify(projects));
+        res.end();
+      });
+  } catch (e) {
+    console.error(e);
+  }
+});//end router.post('/retrieveProjects',
+
+router.post('/retrieveConfigs', function(req, res, next) {
+  console.log('/retrieveConfigs');
+  try {
+    let configs = [];
+    fs.readdir(path.join('/', 'config'), (err, files) => {
+      if (err) {
+        console.error(err);
+      }
+      files.forEach(file => {
+        console.log(file);
+        // TODO: change isDirectory to check for .properties
+        const checkFile = path.parse(file);
+        if (checkFile.ext === '.properties'){
+          configs.push(checkFile.name)
+          }
+        });
+        console.log(configs);
+        res.setHeader("Content-Type", "text/html");
+        res.write(JSON.stringify(configs));
+        res.end();
+      });
+  } catch (e) {
+    console.error(e);
+  }
+});//end router.post('/retrieveProjects',
+
+router.post('/retrievePropertiesFile', function(req, res, next){
+  try {
+    fs.readFile(path.join('/','config', req.body.propertiesFile), 'utf8', function (err,data) {
+      if (err){
+        console.log(err);
+      }
+      console.log(data);
+      res.setHeader("Content-Type", "text/html");
+      res.write(JSON.stringify({data : data}));
+      res.end();
+    });
+  } catch (e) {
+    console.error(e);
+  }
+})
+
+router.post('/javadocsmodulegetter', function(req, res, next) {
+  try {
+    console.log(req.body.moduleJavaClassPath);
+    let modPathString = req.body.moduleJavaClassPath;
+    modPathString = modPathString.concat('.html');
+    const modPathArray = modPathString.split('/');
+    // console.log(path.join.apply(null, modPathArray));
+    fs.readFile(path.join(bljDir, 'docs', path.join.apply(null, modPathArray)), 'utf8', function (err,data) {
+      if (err){
+        console.log(err);
+      }else{
+        console.log(data);
+        res.setHeader("Content-Type", "text/html");
+        res.write(data);
+        res.end();
+      }
+    });
+
+  } catch (e) {
+    console.error(e);
+  } finally {
+
+  }
+});
 //__dirname resolves to /app/biolockj/web_app/routes
 
 router.get('/results', function(req, res, next) {
   res.render('results', { title: 'BioLockJ' });
 });
 
+router.post('/saveConfigToGui', function(req, res, next) {
+  console.log('made it to /saveConfigToGui');
+  try {
+    console.log(req.body.configName);
+    indexAux.saveConfigToLocal(req.body.configName, req.body.configText);
+    res.setHeader('Content-Type', 'text/html');
+    res.write('Server Response: config saved!');
+    res.end();
+  } catch (e) {
+    console.log(e);
+  }
+})
+
 router.post('/defaultproperties', function(req, res, next) {
-  // console.log(req.body);
-  // const body = JSON.parse(req.body);
-  // console.log('body', body);
-  if (req.body.docker === true){
-    fs.readFile(path.join('..','resources','config','default','docker.properties'), 'utf8', function (err,data) {
-    if (err) {
-      return console.log(err);
-    }
-    console.log(data);
-    res.setHeader("Content-Type", "text/html");
-    res.write(data);
-    res.end();
-    });//end fs.readFile
-  }else if(req.body.standard === true){
-    fs.readFile(path.join('..','resources','config','default','standard.properties'), 'utf8', function (err,data) {
-    if (err) {
-      return console.log(err);
-    }
-    console.log(data);
-    res.setHeader("Content-Type", "text/html");
-    res.write(data);
-    res.end();
-    });//end fs.readFile
-  }else{
-    console.log('else');
-    console.log(req.body.file);
-
-    var filePath = req.body.file;
-    console.log("filePath: ", filePath);
-    filePath = filePath.replace(/^\$BLJ/g, '');
-    console.log(filePath);
-    //filePath = path.parse(filePath);
-    //console.log('filePath', filePath);
-    console.log('path.join(bljDir, filePath)', path.join(bljDir, filePath));
-    fs.readFile(path.join(bljDir, filePath), 'utf8', function (err,data) {
-    if (err) {
-      return console.log(err);
-    }
-    console.log(data);
-    res.setHeader("Content-Type", "text/html");
-    res.write(data);
-    res.end();
-    });//end fs.readFile
-    }
-
+  console.log(req.body.file);
+  var filePath = req.body.file;
+  console.log("filePath: ", filePath);
+  filePath = filePath.replace(/^\$BLJ/g, '');
+  console.log(filePath);
+  //filePath = path.parse(filePath);
+  //console.log('filePath', filePath);
+  console.log('path.join(bljDir, filePath)', path.join(bljDir, filePath));
+  fs.readFile(path.join(bljDir, filePath), 'utf8', function (err,data) {
+  if (err) {
+    return console.log(err);
+  }
+  console.log(data);
+  res.setHeader("Content-Type", "text/html");
+  res.write(data);
+  res.end();
+  });//end fs.readFile
 });//end router.post('/defaultproperties'...
 
 //currently for docker only
@@ -116,7 +191,7 @@ router.post('/checkProjectExists', function(req, res, next) {
 
 router.post('/launch', function(req, res, next) {
   console.log('entered /launch');
-  const configLocal = path.join(HOST_BLJ,'resources','config','gui');
+  const configHost = path.join(HOST_BLJ,'resources','config','gui');
   //const configPath = 'config';
   try {
     console.log('entered try catch');
@@ -126,15 +201,18 @@ router.post('/launch', function(req, res, next) {
     const paramValues = req.body.paramValues;
     let launchArg = req.body.partialLaunchArg;
     let configName = paramValues[paramKeys.indexOf('project.configFile')];
+    if (!configName.endsWith('.properties')){
+      configName = configName.concat('.properties');
+    }
 
     const configText = indexAux.formatAsFlatFile(modules, paramKeys, paramValues);
     indexAux.saveConfigToLocal(configName,configText);
-    launchArg['config'] = path.join(configLocal, configName);
+    launchArg['config'] = path.join(configHost, configName);
 
     var launchCommand;
 
     switch (req.body.launchAction) {
-      case 'restartProject':
+      case 'restartFromCheckPoint':
         console.log('restart request: ', req.body.restartProjectPath);
         const fullRestartPath = path.join(bljDir,req.body.restartProjectPath);
         console.log(fullRestartPath);
@@ -143,7 +221,7 @@ router.post('/launch', function(req, res, next) {
         indexAux.runLaunchCommand(launchCommand, Stream);
 
         break;
-      case 'eraseRestart':
+      case 'eraseThenRestart':
       try {
         const eraseDir = req.body.restartProjectPath;
         console.log(eraseDir);
@@ -165,7 +243,6 @@ router.post('/launch', function(req, res, next) {
           }else{
             console.log('p cannot be root');
           }
-
         };
         deleteFolderRecursive(eraseDir);
         launchCommand = indexAux.createFullLaunchCommand(launchArg);
@@ -177,7 +254,7 @@ router.post('/launch', function(req, res, next) {
       }
 
         break;
-      case 'launch':
+      case 'launchNew':
         launchCommand = indexAux.createFullLaunchCommand(launchArg);
         console.log('launching!');
         indexAux.runLaunchCommand(launchCommand, Stream);
@@ -187,9 +264,9 @@ router.post('/launch', function(req, res, next) {
       default:
 
     }
-      res.setHeader('Content-Type', 'text/html');
-      res.write('Server Response: project launched!');
-      res.end();
+    res.setHeader('Content-Type', 'text/html');
+    res.write('Server Response: project launched!');
+    res.end();
 
   } catch (e) {
     console.error(e);
@@ -209,7 +286,6 @@ router.get('/streamLog', function(request, response){
     //response.write("event: " + String(event) + "\n" + "data: " + JSON.stringify(data) + "\n\n");
   });
 });
-
 
 //begin serverside events
 router.get('/streamProgress', function(request, response){
@@ -243,8 +319,7 @@ module.exports = router;
 // // also generally emit 'rename'
 // })
 
-
-function pipelineProjectName(configName){
+function pipelineProjectName(configName){//gets the name of the BLJ created pipeline
   if (configName.endsWith('.properties')){
     configName = configName.replace('.properties', '')
   }
@@ -259,6 +334,34 @@ function pipelineProjectName(configName){
   const projectPipelinePath = path.join('/','pipeline', c );
   return projectPipelinePath;
 }
+
+router.post('/startAws', function(req, res, next) {
+  /*
+  The components of the formData should be:
+  AWSACCESSKEYID, AWSSECRETACCESSKEY, REGION, OUTPUTFORMAT, PROFILE
+  */
+  console.log('in AWS');
+  try {
+    console.dir(req.body.formData);
+    const sys = require('util');
+    const exec = require('child_process').exec;
+    exec('git clone https://github.com/mjzapata/AWSBatchGenomicsStack.git', function(err, stdout, stderr) {
+      console.log(stdout);
+      console.error(err);
+      console.error(stderr);
+    });
+    exec(`AWSBatchGenomicsStack/webapp/writeAWScredentials.sh ${req.body.formData.PROFILE} ${req.body.formData.REGION} ${req.body.formData.OUTPUTFORMAT} ${req.body.formData.AWSACCESSKEYID} ${req.body.formData.AWSSECRETACCESSKEY}`, function(err, stdout, stderr) {
+      console.log(stdout);
+      console.error(err);
+      console.error(stderr);
+    })
+    res.setHeader('Content-Type', 'text/html');
+    res.write('Server Response: AWS launched!');
+    res.end();
+  } catch (e) {
+    console.error(e);
+  }
+});
 
 console.log(process.env.BLJ.toString());
 

--- a/web_app/views/config.hbs
+++ b/web_app/views/config.hbs
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="./stylesheets/config.css" />
 <div class="nav-bar">
   <div class="dropdown">
-    <button class="dropbtn" onclick="projectOptions()">Projects</button>
+    <button class="dropbtn" onclick="projectOptions()">Projects (Click here to start)</button>
     <div class="dropdown-content" id="projects">
       <a onclick="newProj()" href="#">New</a>
       <a onclick="openProjDisplay()" href="#">Open local config file</a>
@@ -15,7 +15,7 @@
 
 <div id="openConfig" class="menu">
   <form class='' id=localFileForm>
-    Select BiolockJ configuration file
+    Select BioLockJ configuration file
     <input type="file" accept=".txt,.properties" id="localFile">
   </form>
 </div>
@@ -39,6 +39,7 @@
     <button class="tablinks" onclick="openTab(event, 'kraken2Tab')">Kraken2</button>
     <button class="tablinks" onclick="openTab(event, 'metaphlanTab')">MetaPhlAn</button>
     <button class="tablinks" onclick="openTab(event, 'slimmTab')">SLIMM</button>
+    <button id='AwsButton' class="tablinks hidden" onclick="openTab(event, 'AWS')">AWS</button>
   </div>
   <!--tabbed menu-->
 <form id="configForm" class="" action="" method="post">
@@ -626,7 +627,51 @@ For fastq, typically “@”.)<h5></p>
 
 </form> <!--End of configForm -->
 
-</div>
+  <div id="AWS" class="tabcontent">
+    <fieldset>
+      <legend>AWS Set-up</legend>
+    <form id='AwsForm' class="" action="#" method="post">
+      <p>*AWS Secret Key ID:*<input type="text" name="AWSACCESSKEYID"></p>
+      <p>AWS Secret Access Key <input required type="text" name="AWSSECRETACCESSKEY"></p>
+      <p>Please select the geographic area in which you live. Subsequent configuration
+    questions will narrow this down by presenting a list of cities, representing
+    the time zones in which they are located.
+      <select class="" name="REGION">
+        <option default value="us-east-1">us-east-1</option>
+        <option value="1">Africa</option>
+        <option value="2">America</option>
+        <option value="3">Antarctica</option>
+        <option value="4">Australia</option>
+        <option value="5">Arctic</option>
+        <option value="6">Asia</option>
+        <option value="7">Atlantic</option>
+        <option value="8">Europe</option>
+        <option value="9">Indian</option>
+        <option value="10">Pacific</option>
+        <option value="11">SystemV</option>
+        <option value="10">Pacific</option>
+        <option value="11">SystemV</option>
+        <option value="12">US</option>
+        <option value="13">Etc</option>
+      </select>
+      </p>
+      <p>Default Output Format: <select class="" name="OUTPUTFORMAT">
+        <option default value="text">text</option>
+      </select></p>
+      <p>Profile:
+        <select required class="" name="PROFILE">
+          <option value="default">default</option>
+        </select>
+      </p>
+      <p id="AWSOutput"></p>
+      <button type="button" id='submitAWS' name="button">Start AWS Service</button>
+    </form>
+  </fieldset>
+    <button class="createDownload">Create configuration file for download</button>
+    <a class="downloadlink">Download configuration file to default directory</a>
+    <button type="button" class="openLaunchModal">Ready to Launch BioLockJ!</button>
+  </div>
+</div><!-- End Menu tab -->
 
 <!-- The Modal that appears after ready to launch button is pressed -->
 <div id="launchConsole" class="modal">
@@ -635,13 +680,23 @@ For fastq, typically “@”.)<h5></p>
     <span class="closeModal">&times;</span>
     <div id='progress'></div>
     <div id='log'></div>
-
-  <div id="restartOrErase" class="hidden">
-    <span id="restartOrEraseText"></span><br>
-    <button type="button" id='restartProject' name="restartProject">Restart project from last check point</button>
-    <button type="button" id="eraseRestart" name="eraseRestart">Erase previsous project with this name and then launch BioLockJ</button>
-  </div>
-    <button type="button" class='hidden' id="launchBlj" name="launchBlj">Launch</button>
+  <form id="projectLaunchOptions">
+    <fieldset>
+      <legend>Project Launch Options</legend>
+      Use this configuation to start a new project.
+      <input type="radio" name="projLaunch" value="launchNew" checked>
+      <p id="projOptFieldSet"></p>
+    </fieldset>
+    <fieldset>
+      <legend>If restarting, you may restart from last checkpoint (keep previous progress) or from beginning (remove all progress).</legend>
+      <select class="" name="restartOption">
+        <option value="">Options for restarting a project</option>
+        <option value="restartFromCheckPoint">Restart from last checkpoint (keep previous progress)</option>
+        <option value="eraseThenRestart">Restart from beginning (erase all current progress)</option>
+      </select>
+    </fieldset>
+  </form>
+    <button type="button" class='' id="launchBlj" name="launchBlj">Launch</button>
   </div>
 
 </div><!-- end launch console -->
@@ -679,6 +734,8 @@ For fastq, typically “@”.)<h5></p>
   <span class='hidden' id='hackForDownload'></span>
   <!-- <button form='configForm' type="submit" name="button" class='hidden'></button> -->
 </div>
+
+
 
 <script type="text/javascript" src="./javascripts/config_menus.js"></script>
 <script type="text/javascript" src="./javascripts/config_config.js"></script>

--- a/web_app/views/index.hbs
+++ b/web_app/views/index.hbs
@@ -1,2 +1,13 @@
+<link rel="stylesheet" type="text/css" href="./stylesheets/splash.css" />
 
-<img src="./images/BioLockJ_Block_green.svg">
+<!-- <img src="./images/BioLockJ_Block_green.svg"> -->
+
+<div id='configRedirect' class="fileViewer">
+  <a href="/config">Create, edit, or upload BioLockJ configuation file)</a>
+</div>
+
+<div id='projectsViewer' class="fileViewer">
+  Existing projects
+</div>
+
+<script type="text/javascript" src="./javascripts/splash.js"></script>

--- a/web_app/views/layouts/layout.hbs
+++ b/web_app/views/layouts/layout.hbs
@@ -8,17 +8,13 @@
   <link rel="shortcut icon" type="image/x-icon" href="/images/favicon.ico">
 </head>
 <body>
-<button onclick="location.href='/';">Splash page</button>
-<button onclick="location.href='/config';">Configure a project</button>
+<!-- <button onclick="location.href='/';">Splash page</button> -->
+<!-- <button onclick="location.href='/config';">Configure a project</button> -->
 <!-- <button onclick="location.href='/progress';">Progress of current project</button>
 <button onclick="location.href='/results';">Results</button><br> -->
 
   {{{ body }}}
 
-
-<script type="text/javascript">
-
-</script>
 </body>
-
+<script type="text/javascript" src="./javascripts/layout.js"></script>
 </html>


### PR DESCRIPTION
**Updates to GUI:**

Changes to '/config': 
- Rewrite eventlistener of launch buttons on config form to allow users to pick from any previous project to restart, even if the name of the project and the config don't match.  
- All saving and loading is done from docker/host.
- Add AWS tab that has a separate form from the config form to take log-in parameters of AWS.  The data is sent to node where Malcolm's script is run.  The node server then downloads Malcolm's git repository and runs a shell script.
- Module list element hover text reroute to node server which dispenses requested javadoc.  Update javadoc parser to handle HTML rather than plain text.
- Updates to accommodate changes to the master config and new modules

Changes to '/':
- Created a splash page from which users can chose what they want to do.  Right now they can see projects and navigate to '/config'


