### PR TITLE
Rsync reports

### DIFF
--- a/resources/R/BioLockJ_Lib.R
+++ b/resources/R/BioLockJ_Lib.R
@@ -185,6 +185,15 @@ getNumericFields <- function() {
 	return( getProperty("R_internal.numericFields", vector( mode="character" ) ) )
 }
 
+# Get the temp dir for the current module, if it does not exist, create it.
+getOutputDir <- function(){
+	path = file.path( file.path(getModuleDir(), "output") )
+	if ( !dir.exists(path)){
+		dir.create( path )
+	}
+	return( path )
+}
+
 # Return file path of file in rootDir, with the pipeline name appended as a prefix to name
 getPath <- function( rootDir, name ) {
 	return( file.path( rootDir, paste0( basename( getPipelineDir() ), "_", name ) ) )
@@ -253,6 +262,15 @@ getCountMetaTable <- function( level=NULL ) {
 	
 	logInfo( "Read count table", countMetaFile )
 	return( countMetaTable )
+}
+
+# Get the temp dir for the current module, if it does not exist, create it.
+getTempDir <- function(){
+	path = file.path( file.path(getModuleDir(), "temp") )
+	if ( !dir.exists(path)){
+		dir.create( path )
+	}
+	return( path )
 }
 
 # Return the name of statistical test used to generate P-Values for a given attribute

--- a/resources/R/R_CalculateStats.R
+++ b/resources/R/R_CalculateStats.R
@@ -16,7 +16,7 @@ buildSummaryTables <- function( reportStats, level ) {
 			df[, length(df)+1] = getValuesByName( reportStats[[i]], fields[j] )
 			names(df)[length(df)] = fields[j]
 		}
-		fileName = getPath( file.path( getModuleDir(), "output" ), paste0( level, "_", names(reportStats)[i] ) )
+		fileName = getPath( getOutputDir(), paste0( level, "_", names(reportStats)[i] ) )
 		logInfo( paste( "Saving output file", fileName ) )
 		write.table( df, file=fileName, sep="\t", row.names=FALSE )
 	}
@@ -164,8 +164,8 @@ getP_AdjustLen <- function( names ) {
 main <- function() {
 	importLibs( c( "coin", "Kendall" ) ) 
 	for( level in taxaLevels() ) {
-		if( doDebug() ) sink( file.path( getModuleDir(), "temp", paste0("debug_CalculateStats_", level, ".log") ) )
-		reportStats = calculateStats( level )
+	  if( doDebug() ) sink( file.path( getTempDir(), paste0("debug_CalculateStats_", level, ".log") ) )
+	  reportStats = calculateStats( level )
 		if( is.null( reportStats ) ) {
 			logInfo( c( level, "is empty, verify contents of table:", inputFile ) )
 		} else {

--- a/resources/R/R_PlotMds.R
+++ b/resources/R/R_PlotMds.R
@@ -8,7 +8,7 @@ main <- function() {
    mdsFields = getProperty( "r_PlotMds.reportFields", c( getBinaryFields(), getNominalFields() )  )
 
    for( level in taxaLevels() ) {
-      if( doDebug() ) sink( file.path( getModuleDir(), "temp", paste0("debug_BuildMdsPlots_", level, ".log") ) )
+      if( doDebug() ) sink( file.path( getTempDir(), paste0("debug_BuildMdsPlots_", level, ".log") ) )
 
       countTable = getCountTable( level )
       if( is.null( countTable ) ) { next }
@@ -26,7 +26,7 @@ main <- function() {
       logInfo( "Save Eigen value table", pcoaFileName )
       
       # Make plots
-      outputFile = paste0( getPath( file.path(getModuleDir(), "output"), paste0(level, "_MDS.pdf" ) ) )
+      outputFile = paste0( getPath( getOutputDir(), paste0(level, "_MDS.pdf" ) ) )
 
       if (numAxis < 4 ) {
          pdf( outputFile, width = 7, height = 7)

--- a/resources/R/R_PlotOtus.R
+++ b/resources/R/R_PlotOtus.R
@@ -76,9 +76,9 @@ getLas <- function( labels ) {
 
 # Called by BioLockJ_Lib.R runProgram() to execute this script
 main <- function() {
-   
+
    for( level in taxaLevels() ) {
-      if( doDebug() ) sink( file.path( getModuleDir(), "temp", paste0("debug_BuildOtuPlots_", level, ".log") ) )
+      if( doDebug() ) sink( file.path( getTempDir(), paste0("debug_BuildOtuPlots_", level, ".log") ) )
       
       countTable = getCountTable( level )
       if( is.null( countTable ) ) { next }
@@ -100,7 +100,7 @@ main <- function() {
 
       metaColColors = getColorsByCategory( metaTable )
 
-      outputFile = getPath( file.path(getModuleDir(), "output"), paste0(level, "_OTU_plots.pdf") )
+      outputFile = getPath( getOutputDir(), paste0(level, "_OTU_plots.pdf") )
 
       if( length( reportCols ) < 5 ) {
          pdf( outputFile, width = 7, height = 7)

--- a/resources/R/R_PlotPvalHistograms.R
+++ b/resources/R/R_PlotPvalHistograms.R
@@ -65,10 +65,10 @@ main <- function() {
    pvalCutoff = getProperty("r.pvalCutoff", 0.05)
 
    for( level in taxaLevels() ) {
-      if( doDebug() ) sink( file.path( getModuleDir(), "temp", paste0("debug_BuildPvalHistograms_", level, ".log") ) )
+      if( doDebug() ) sink( file.path( getTempDir(), paste0("debug_BuildPvalHistograms_", level, ".log") ) )
 
       # create empty pdf
-      pdf( getPath( file.path(getModuleDir(), "output"), paste0(level, "_histograms.pdf") ) )
+     pdf( getPath( getOutputDir(), paste0(level, "_histograms.pdf") ) )
       par( mfrow=c(2, 2), las=1, mar=c(5,4,5,1)+.1 )
 
 
@@ -89,7 +89,7 @@ main <- function() {
       # order attributes based on the fraction of tests with a p-value below <pvalCutoff>
       orderBy = apply(ranks[2:3],1, max, na.rm=TRUE)
       ranks = ranks[order(orderBy, decreasing=TRUE),]
-      fname = getPath( file.path(getModuleDir(), "temp"), paste0(level, "_fractionBelow-", pvalCutoff, ".tsv") )
+      fname = getPath( getTempDir(), paste0(level, "_fractionBelow-", pvalCutoff, ".tsv") )
       write.table(ranks, file=fname, sep="\t", quote=FALSE, row.names=FALSE)
 
       # plot histograms in the same order they have in the ranks table

--- a/script/blj_download
+++ b/script/blj_download
@@ -1,7 +1,7 @@
 #!/bin/bash
 ############################################################################
 ##                                                                        ##
-##  This script prints the scp command needed to download analysis.       ##
+##  This script prints the command needed to download analysis.           ##
 ##  If the current directory is not a BioLockJ pipeline, print the        ##
 ##  scp command for the most recent pipeline executed.                    ##
 ##                                                                        ##
@@ -14,10 +14,10 @@ pipeline=$(most_recent_pipeline)
 SUM=summary.txt
 MSG=
 if [ -f $SUM ]; then
-	val=$(grep -B 1 "mkdir" $SUM)
+	val=$(grep -B 3 "rsync" $SUM)
 	[ ${#val} -gt 0 ] && MSG="$val"
 elif [ ${#pipeline} -gt 0 ]; then
-	val=$(grep -B 1 "mkdir" "$pipeline/$SUM")
+	val=$(grep -B 3 "rsync" "$pipeline/$SUM")
 	[ ${#val} -gt 0 ] && MSG="$val"
 else
 	MSG="No completed pipelines found in BLJ_PROJ: $BLJ_PROJ"

--- a/src/biolockj/BioLockJ.java
+++ b/src/biolockj/BioLockJ.java
@@ -216,8 +216,9 @@ public class BioLockJ
 	 * <ol>
 	 * <li>Initialize {@link biolockj.Log} file using the name of the pipeline root directory
 	 * <li>Update summary #Attempts count
-	 * <li>If pipeline status = {@value biolockj.Constants#BLJ_COMPLETE}
 	 * <li>Delete status file {@value biolockj.Constants#BLJ_FAILED} in pipeline root directory
+	 * <li>If pipeline status = {@value biolockj.Constants#BLJ_COMPLETE}
+	 * <li>Delete file {@value biolockj.util.DownloadUtil#DOWNLOAD_LIST} in pipeline root directory
 	 * </ol>
 	 * 
 	 * @throws Exception if errors occur
@@ -230,6 +231,10 @@ public class BioLockJ
 		Log.info( BioLockJ.class, "Initializing Restarted Pipeline - this may take a couple of minutes..." );
 
 		SummaryUtil.updateNumAttempts();
+		if (Config.isOnCluster()) {
+			DownloadUtil.getDownloadListFile().delete();
+		}
+		
 		final File f = new File( Config.pipelinePath() + File.separator + Constants.BLJ_FAILED );
 		if( f.exists() )
 		{

--- a/src/biolockj/module/report/r/R_CalculateStats.java
+++ b/src/biolockj/module/report/r/R_CalculateStats.java
@@ -45,20 +45,6 @@ public class R_CalculateStats extends R_Module implements BioModule
 	}
 
 	/**
-	 * Return the set of file extensions available for download by {@link biolockj.util.DownloadUtil}
-	 * 
-	 * @return Set of file extensions
-	 * @throws Exception if errors occur
-	 */
-	@Override
-	public TreeSet<String> scpExtensions() throws Exception
-	{
-		final TreeSet<String> set = super.scpExtensions();
-		set.add( TSV_EXT.substring( 1 ) );
-		return set;
-	}
-
-	/**
 	 * Get the stats file for the given fileType and taxonomy level.
 	 * 
 	 * @param module Calling module

--- a/src/biolockj/module/report/r/R_Module.java
+++ b/src/biolockj/module/report/r/R_Module.java
@@ -298,30 +298,6 @@ public abstract class R_Module extends ScriptModuleImpl implements ScriptModule
 	}
 
 	/**
-	 * Return the set of file extensions available for download by {@link biolockj.util.DownloadUtil} Add
-	 * {@value #TSV_EXT} to super class set.
-	 * 
-	 * @return Set of file extensions
-	 * @throws Exception if errors occur
-	 */
-	public TreeSet<String> scpExtensions() throws Exception
-	{
-		final TreeSet<String> set = new TreeSet<>();
-		set.add( R_EXT.substring( 1 ) );
-		if( Config.getBoolean( this, R_Module.R_SAVE_R_DATA ) )
-		{
-			set.add( R_DATA_EXT.substring( 1 ) );
-		}
-		if( !Config.getBoolean( this, Constants.PROJECT_DELETE_TEMP_FILES )
-				&& Config.getBoolean( this, R_Module.R_DEBUG ) )
-		{
-			set.add( LOG_EXT.substring( 1 ) );
-		}
-
-		return set;
-	}
-
-	/**
 	 * Add {@link biolockj.module.report.r.R_CalculateStats} to standard {@link #getPreRequisiteModules()}
 	 */
 	protected List<String> getStatPreReqs() throws Exception

--- a/src/biolockj/module/report/r/R_PlotEffectSize.java
+++ b/src/biolockj/module/report/r/R_PlotEffectSize.java
@@ -12,7 +12,6 @@
 package biolockj.module.report.r;
 
 import java.util.List;
-import java.util.TreeSet;
 import biolockj.Config;
 import biolockj.exception.ConfigViolationException;
 import biolockj.module.ScriptModule;
@@ -55,22 +54,8 @@ public class R_PlotEffectSize extends R_Module implements ScriptModule
 		return preReqs;
 	}
 
-	/**
-	 * Return the set of file extensions available for download by {@link biolockj.util.DownloadUtil} Add
-	 * {@value #PDF_EXT} to super class set.
-	 * 
-	 * @return Set of file extensions
-	 * @throws Exception if errors occur
-	 */
-	@Override
-	public TreeSet<String> scpExtensions() throws Exception
-	{
-		final TreeSet<String> set = super.scpExtensions();
-		set.add( PDF_EXT.substring( 1 ) );
-		return set;
-	}
-
 	private final String NO_FOLD_CHANGE = "r.plotEffectSize.disableFoldChange";
 	private final String NO_COHENS_D = "r.plotEffectSize.disableCohensD";
 	private final String NO_R2 = "r.plotEffectSize.disableRSquared";
+	
 }

--- a/src/biolockj/module/report/r/R_PlotMds.java
+++ b/src/biolockj/module/report/r/R_PlotMds.java
@@ -11,7 +11,6 @@
  */
 package biolockj.module.report.r;
 
-import java.util.TreeSet;
 import biolockj.Config;
 import biolockj.module.ScriptModule;
 
@@ -35,28 +34,6 @@ public class R_PlotMds extends R_Module implements ScriptModule
 			throw new Exception( "Config property [" + R_MDS_NUM_AXIS + "] must be > 2" );
 		}
 	}
-
-	/**
-	 * Return the set of file extensions available for download by {@link biolockj.util.DownloadUtil} Add
-	 * {@value #PDF_EXT} to super class set.
-	 * 
-	 * @return Set of file extensions
-	 * @throws Exception if errors occur
-	 */
-	@Override
-	public TreeSet<String> scpExtensions() throws Exception
-	{
-		final TreeSet<String> set = super.scpExtensions();
-		set.add( PDF_EXT.substring( 1 ) );
-		set.add( TSV_EXT.substring( 1 ) );
-		return set;
-	}
-
-	/**
-	 * {@link biolockj.Config} List property: {@value #MDS_REPORT_FIELDS}<br>
-	 * List metadata fields to generate MDS ordination plots.
-	 */
-	public static final String R_MDS_REPORT_FIELDS = "r_PlotMds.reportFields";
 
 	/**
 	 * {@link biolockj.Config} property: {@value #R_MDS_DISTANCE} defines the distance index to use in the capscale

--- a/src/biolockj/module/report/r/R_PlotOtus.java
+++ b/src/biolockj/module/report/r/R_PlotOtus.java
@@ -12,7 +12,6 @@
 package biolockj.module.report.r;
 
 import java.util.List;
-import java.util.TreeSet;
 import biolockj.module.ScriptModule;
 
 /**
@@ -36,18 +35,4 @@ public class R_PlotOtus extends R_Module implements ScriptModule
 		return getStatPreReqs();
 	}
 
-	/**
-	 * Return the set of file extensions available for download by {@link biolockj.util.DownloadUtil} Add
-	 * {@value #PDF_EXT} to super class set.
-	 * 
-	 * @return Set of file extensions
-	 * @throws Exception if errors occur
-	 */
-	@Override
-	public TreeSet<String> scpExtensions() throws Exception
-	{
-		final TreeSet<String> set = super.scpExtensions();
-		set.add( PDF_EXT.substring( 1 ) );
-		return set;
-	}
 }

--- a/src/biolockj/module/report/r/R_PlotPvalHistograms.java
+++ b/src/biolockj/module/report/r/R_PlotPvalHistograms.java
@@ -12,7 +12,6 @@
 package biolockj.module.report.r;
 
 import java.util.List;
-import java.util.TreeSet;
 import biolockj.Config;
 import biolockj.module.ScriptModule;
 
@@ -38,18 +37,4 @@ public class R_PlotPvalHistograms extends R_Module implements ScriptModule
 		return getStatPreReqs();
 	}
 
-	/**
-	 * Return the set of file extensions available for download by {@link biolockj.util.DownloadUtil} Add
-	 * {@value #PDF_EXT} to super class set.
-	 * 
-	 * @return Set of file extensions
-	 * @throws Exception if errors occur
-	 */
-	@Override
-	public TreeSet<String> scpExtensions() throws Exception
-	{
-		final TreeSet<String> set = super.scpExtensions();
-		set.add( PDF_EXT.substring( 1 ) );
-		return set;
-	}
 }

--- a/src/biolockj/util/DownloadUtil.java
+++ b/src/biolockj/util/DownloadUtil.java
@@ -11,13 +11,22 @@
  */
 package biolockj.util;
 
+import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.IOFileFilter;
+import org.apache.commons.io.filefilter.NameFileFilter;
+import org.apache.commons.io.filefilter.WildcardFileFilter;
 import biolockj.*;
 import biolockj.module.BioModule;
 import biolockj.module.ScriptModule;
@@ -25,6 +34,7 @@ import biolockj.module.report.Email;
 import biolockj.module.report.JsonReport;
 import biolockj.module.report.r.R_Module;
 import biolockj.module.report.taxa.AddMetadataToTaxaTables;
+import biolockj.module.report.taxa.BuildTaxaTables;
 
 /**
  * This utility is used to validate the metadata to help ensure the format is valid R script input.
@@ -36,7 +46,50 @@ public final class DownloadUtil
 	{}
 
 	/**
-	 * If running on cluster, build scp command for user to download pipeline analysis.<br>
+	 * Add files to {@value biolockj.util.DownloadUtil#DOWNLOAD_LIST} in pipeline root directory. If doDownlaod = false,
+	 * then the file and its size are noted in the download file in a commented out line. This makes it easy for the
+	 * user to see how big the files is and add it to the list ad-hoc.
+	 * 
+	 * @param files - files to add to the download list
+	 * @param doDownload - true/false
+	 * @throws Exception
+	 */
+	private static void addToDownloadList( Collection<File> files ) throws Exception
+	{
+		final File dlFile = getDownloadListFile();
+		final BufferedWriter writer = new BufferedWriter( new FileWriter( dlFile, true ) );
+
+		final File pipeRoot = new File( Config.pipelinePath() );
+		for( File file: files )
+		{
+			if( FileUtils.sizeOf( file ) != 0 && !file.isDirectory())
+			{
+				String relPath = pipeRoot.toURI().relativize( file.toURI() ).toString();
+				String sizeString = RSYNC_COMMENT + relPath + " --> "
+						+ FileUtils.byteCountToDisplaySize( FileUtils.sizeOf( file ) );
+				writer.write( sizeString + RETURN );
+				writer.write( relPath + RETURN );
+			}
+		}
+		writer.close();
+	}
+
+	/**
+	 * Get a directory name filter to include output and (optionally) script folders in file searches.
+	 * @param includeScript
+	 * @return a file name filter
+	 * @throws Exception
+	 */
+	protected static IOFileFilter getDirFilter( boolean includeScript ) throws Exception
+	{
+		ArrayList<String> dirFilter = new ArrayList<String>();
+		if (includeScript) { dirFilter.add( "script" ); }
+		dirFilter.add( "output" );
+		return new NameFileFilter( dirFilter );
+	}
+
+	/**
+	 * If running on cluster, build command for user to download pipeline analysis.<br>
 	 * <p>
 	 * The pipeline analysis is extracted from the last module output directory (except Email).<br>
 	 * Download target = ModuleUtil.getDownloadDir() on the local workstation.<br>
@@ -51,55 +104,106 @@ public final class DownloadUtil
 		final List<BioModule> modules = getDownloadModules();
 		if( Config.isOnCluster() && modules != null && getDownloadDirPath() != null )
 		{
-			String status = "Complete";
+			final File pipeRoot = new File( Config.pipelinePath() );
 
-			String targets = getSrc( getExts( null, false ) );
-			BigInteger downloadSize = FileUtils.sizeOfAsBigInteger( Log.getFile() );
-			downloadSize = downloadSize.add( FileUtils.sizeOfAsBigInteger( SummaryUtil.getSummaryFile() ) );
-			downloadSize = downloadSize.add( FileUtils.sizeOfAsBigInteger( PropUtil.getMasterConfig() ) );
-
-			if( modules.get( modules.size() - 1 ) instanceof R_Module )
-			{
-				final File runAll = makeRunAllScript( modules );
-				downloadSize = downloadSize.add( FileUtils.sizeOfAsBigInteger( runAll ) );
-			}
 			boolean hasRmods = false;
+			String status = "completed";
+			Set<File> files = new TreeSet<File>();
 			for( final BioModule module: modules )
 			{
-				final String modNum = BioLockJUtil.formatDigits( module.getID(), 2 );
-				downloadSize = downloadSize.add( FileUtils.sizeOfAsBigInteger( module.getOutputDir() ) );
+				Log.info( DownloadUtil.class, "Updating download list for " + module.getClass().getSimpleName() );		
 				if( module instanceof R_Module )
 				{
 					hasRmods = true;
-					targets += " " + getSrc(
-							modNum + "*" + File.separator + "*" + File.separator + getExts( (R_Module) module, true ) );
-					downloadSize = downloadSize
-							.add( FileUtils.sizeOfAsBigInteger( ( (ScriptModule) module ).getScriptDir() ) );
-					downloadSize = downloadSize.add( FileUtils.sizeOfAsBigInteger( module.getTempDir() ) );
-				}
+					files.addAll( FileUtils.listFiles( module.getModuleDir(), new WildcardFileFilter( "*" ),
+							getDirFilter( true ) ) );
+				} 
 				else
 				{
-					targets += " " + getSrc( modNum + "*" + File.separator + "output" + File.separator + "*" );
+					files.addAll( FileUtils.listFiles( module.getModuleDir(), new WildcardFileFilter( "*" ),
+							getDirFilter( false ) ) );
 				}
-
 				if( !ModuleUtil.isComplete( module ) )
 				{
-					status = "Failed";
+					status = "failed";
 				}
 			}
-			final String pipeRoot = Config.pipelinePath();
-			final String label = status + ( getDownloadModules().size() > 1 ? " Modules --> ": " Module --> " );
-			final String displaySize = FileUtils.byteCountToDisplaySize( downloadSize );
-			final String rDirs = hasRmods
-					? "; mkdir -p " + getDest( BioModule.OUTPUT_DIR ) + "; mkdir " + getDest( BioModule.TEMP_DIR )
-					: "";
-			final String cmd = "src=" + pipeRoot + "; out=" + getDownloadDirPath() + rDirs + "; scp -rp "
-					+ getClusterUser() + "@" + Config.requireString( null, Email.CLUSTER_HOST ) + ":\"" + targets
-					+ "\" " + DEST;
+
+			if( hasRmods )
+			{
+				makeRunAllScript( modules );
+			}
+			
+			files.addAll( Arrays.asList(pipeRoot.listFiles() ) );
+
+			addToDownloadList( files );
+
+			final String label = status + " pipeline -->";
+			final String displaySize = FileUtils.byteCountToDisplaySize( getDownloadSize() );
+			final String cmd = SOURCE + "=" + pipeRoot.getAbsolutePath() + RETURN + "out=" + getDownloadDirPath()
+					+ RETURN + "rsync --times --files-from=:$" + SOURCE + File.separator
+					+ pipeRoot.toURI().relativize( getDownloadListFile().toURI() ) + " " + getClusterUser() + "@"
+					+ Config.requireString( null, Email.CLUSTER_HOST ) + ":$" + SOURCE + " $" + DEST;
 			return "Download " + label + " [" + displaySize + "]:" + RETURN + cmd;
 		}
 
 		return null;
+	}
+
+	/**
+	 * Get the file that has the download list.
+	 * 
+	 * @return File containing list of files to download
+	 * @throws Exception
+	 */
+	public static File getDownloadListFile() throws Exception
+	{
+		final File downloadList = new File( Config.pipelinePath() + File.separator + DOWNLOAD_LIST );
+		if( !downloadList.exists() )
+		{
+			downloadList.createNewFile();
+			final BufferedWriter writer = new BufferedWriter( new FileWriter( downloadList, true ) );
+			final String header = RSYNC_COMMENT + "Use this file with the --files-from argument to rsync." + RETURN
+					+ RSYNC_COMMENT + "See \"" + SummaryUtil.getSummaryFile().getName() + "\" or call "
+					+ DOWNLOAD_SCRIPT + " for full rsync command." + RETURN + RSYNC_COMMENT + "Lines that begin with \""
+					+ RSYNC_COMMENT + "\" are ignored." + RETURN + RSYNC_COMMENT
+					+ "This file is regenerated with each restart; any manual edits are lost." + RETURN + RSYNC_COMMENT
+					+ RETURN + RSYNC_COMMENT;
+			writer.write( header + RETURN );
+			writer.close();
+		}
+		return downloadList;
+	}
+
+	/**
+	 * Get the total size of all files that would be included in download.
+	 * 
+	 * @return
+	 * @throws Exception
+	 */
+	public static BigInteger getDownloadSize() throws Exception
+	{
+		String pipeRoot = Config.pipelinePath();
+
+		BigInteger downloadSize = FileUtils.sizeOfAsBigInteger( Log.getFile() );
+
+		File dlFile = getDownloadListFile();
+
+		BufferedReader reader = new BufferedReader( new FileReader( dlFile ) );
+		String readLine;
+		while( ( readLine = reader.readLine() ) != null )
+		{
+			if( !readLine.startsWith( RSYNC_COMMENT ) )
+			{
+				File f = new File( pipeRoot + File.separator + readLine );
+				downloadSize = downloadSize.add( FileUtils.sizeOfAsBigInteger( f ) );
+			}
+		}
+
+		reader.close();
+
+		return downloadSize;
+
 	}
 
 	/**
@@ -149,10 +253,10 @@ public final class DownloadUtil
 	 * Get the modules to download. Some modules are always included:
 	 * <ul>
 	 * <li>{@link biolockj.module.report.taxa.AddMetadataToTaxaTables}
+	 * <li>{@link biolockj.module.report.taxa.BuildTaxaTables}
 	 * <li>{@link biolockj.module.report.JsonReport}
-	 * <li>Any module that implements {@link biolockj.module.report.r.R_Module} interface
+	 * <li>Any module that inherits from {@link biolockj.module.report.r.R_Module}
 	 * </ul>
-	 * If R modules have run, build local output directory to be included in download via scp command.<br>
 	 *
 	 * @return BioModules to download
 	 */
@@ -161,36 +265,15 @@ public final class DownloadUtil
 		final List<BioModule> modules = new ArrayList<>();
 		try
 		{
-			BioModule lastModule = null;
-			final List<BioModule> rModules = new ArrayList<>();
 			for( final BioModule module: Pipeline.getModules() )
 			{
-				if( ModuleUtil.hasExecuted( module ) && module instanceof JsonReport
-						|| module instanceof AddMetadataToTaxaTables )
+				boolean downloadableType = module instanceof JsonReport || module instanceof AddMetadataToTaxaTables
+						|| module instanceof BuildTaxaTables || module instanceof R_Module;
+				if( ModuleUtil.hasExecuted( module ) && downloadableType )
 				{
 					modules.add( module );
 				}
-				else if( ModuleUtil.hasExecuted( module ) && module instanceof R_Module )
-				{
-					rModules.add( module );
-				}
-
-				if( ModuleUtil.hasExecuted( module ) && !( module instanceof Email ) )
-				{
-					lastModule = module;
-				}
 			}
-
-			if( lastModule != null && !rModules.isEmpty() )
-			{
-				modules.addAll( rModules );
-			}
-
-			if( !modules.contains( lastModule ) )
-			{
-				modules.add( lastModule );
-			}
-
 			return modules;
 		}
 		catch( final Exception ex )
@@ -200,45 +283,10 @@ public final class DownloadUtil
 		return null;
 	}
 
-	/**
-	 * Get file extensions for each R module to include in scp download command
-	 * 
-	 * @param module R_Module
-	 * @param harRmods Boolean TRUE if R modules in pipeline
-	 * @return REGEX to scp specific file extensions
-	 * @throws Exception if errors occur
-	 */
-	protected static String getExts( final R_Module module, final boolean harRmods ) throws Exception
+	public static File getRunAllRScriptName() throws Exception
 	{
-		if( module == null )
-		{
-			String ext = Constants.LOG_EXT.substring( 1 ) + "," + Constants.TXT_EXT.substring( 1 );
-			if( Config.getConfigFileExt() != null )
-			{
-				ext += "," + Config.getConfigFileExt().substring( 1 );
-			}
-
-			if( harRmods )
-			{
-				return "*.{" + ext + "," + Constants.SH_EXT.substring( 1 ) + "}";
-			}
-			else
-			{
-				return "*.{" + ext + "}";
-			}
-		}
-		else if( module.scpExtensions() == null || module.scpExtensions().isEmpty() )
-		{
-			return "*";
-		}
-
-		final StringBuffer sb = new StringBuffer();
-		for( final String ext: module.scpExtensions() )
-		{
-			sb.append( sb.toString().isEmpty() ? "*.{": "," ).append( ext );
-		}
-		sb.append( "}" );
-		return sb.toString();
+		final File script = new File( Config.pipelinePath() + File.separator + RUN_ALL_SCRIPT );
+		return script;
 	}
 
 	/**
@@ -251,8 +299,9 @@ public final class DownloadUtil
 	protected static File makeRunAllScript( final List<BioModule> modules ) throws Exception
 	{
 
-		final File script = new File( Config.pipelinePath() + File.separator + RUN_ALL_SCRIPT );
-		final BufferedWriter writer = new BufferedWriter( new FileWriter( script ) );
+		final File pipeRoot = new File( Config.pipelinePath() );
+		final File script = getRunAllRScriptName();
+		final BufferedWriter writer = new BufferedWriter( new FileWriter( script, true ) );
 
 		if( Config.getString( null, ScriptModule.SCRIPT_DEFAULT_HEADER ) != null )
 		{
@@ -265,9 +314,11 @@ public final class DownloadUtil
 		{
 			if( mod instanceof R_Module )
 			{
+				String relPath = pipeRoot.toURI().relativize( ( (R_Module) mod ).getPrimaryScript().toURI() )
+						.toString();
 				// do not use exe.Rscript config option, this is a convenience for the users local system not for the
 				// system where biolockj ran.
-				writer.write( "Rscript " + ( (R_Module) mod ).getPrimaryScript().getName() + RETURN );
+				writer.write( "Rscript " + relPath + RETURN );
 			}
 		}
 
@@ -276,25 +327,32 @@ public final class DownloadUtil
 		return script;
 	}
 
-	private static String getDest( final String val )
-	{
-		return DEST + File.separator + val;
-	}
-
-	private static String getSrc( final String val ) throws Exception
-	{
-		return SOURCE + File.separator + val;
-	}
-
 	/**
 	 * {@link biolockj.Config} String property: {@value #DOWNLOAD_DIR}<br>
 	 * Sets the local directory targeted by the scp command.
 	 */
 	protected static final String DOWNLOAD_DIR = "project.downloadDir";
 
-	private static final String DEST = "$out";
+	private static final String DEST = "out";
 	private static final String RETURN = BioLockJ.RETURN;
 	private static final String RUN_ALL_SCRIPT = "Run_All_R" + Constants.SH_EXT;
-	private static final String SOURCE = "$src";
+	private static final String DOWNLOAD_LIST = "downloadList.txt";
+	private static final String SOURCE = "src";
+	private static final String RSYNC_COMMENT = "# ";
+	private static final String DOWNLOAD_SCRIPT = "blj_download";
 
+	/**
+	 * String to remove from cluster.<config option> to make it specific to a given module.
+	 */
+	private static final String PROPERTY_PREFIX = "cluster";
+
+	/**
+	 * Configurable property for listing file extensions to download
+	 */
+	protected static final String DOWNLOAD_EXT = "cluster.downloadExts";
+
+	/**
+	 * Configurable property for listing file extensions to NOT download; this overrides anything in DOWNLOAD_EXT.
+	 */
+	protected static final String DOWNLOAD_EXT_DISABLE = "cluster.downloadExtsDisable";
 }

--- a/src/biolockj/util/RMetaUtil.java
+++ b/src/biolockj/util/RMetaUtil.java
@@ -80,7 +80,7 @@ public final class RMetaUtil
 
 		nominalFields.addAll( Config.getList( module, R_NOMINAL_FIELDS ) );
 		numericFields.addAll( Config.getList( module, R_NUMERIC_FIELDS ) );
-		mdsFields.addAll( Config.getList( module, R_PlotMds.R_MDS_REPORT_FIELDS ) );
+		mdsFields.addAll( Config.getList( module, R_MDS_REPORT_FIELDS ) );
 
 		final List<String> excludeFields = Config.getList( module, R_EXCLUDE_FIELDS );
 
@@ -95,7 +95,7 @@ public final class RMetaUtil
 		verifyMetadataFieldsExist( module, R_REPORT_FIELDS, rScriptFields );
 		verifyMetadataFieldsExist( module, R_NUMERIC_FIELDS, numericFields );
 		verifyMetadataFieldsExist( module, R_NOMINAL_FIELDS, nominalFields );
-		verifyMetadataFieldsExist( module, R_PlotMds.R_MDS_REPORT_FIELDS, mdsFields );
+		verifyMetadataFieldsExist( module, R_MDS_REPORT_FIELDS, mdsFields );
 
 		if( !RuntimeParamUtil.isDirectMode() )
 		{
@@ -579,6 +579,13 @@ public final class RMetaUtil
 	 * R reports must contain at least one valid nominal or numeric metadata field.
 	 */
 	protected static final String R_EXCLUDE_FIELDS = "r.excludeFields";
+	
+	/**
+	 * {@link biolockj.Config} List property: {@value #R_MDS_REPORT_FIELDS}<br>
+	 * Fields listed here must exist in the metadata file.
+	 * 
+	 */
+	protected static final String R_MDS_REPORT_FIELDS = "r_PlotMds.reportFields";
 
 	/**
 	 * {@link biolockj.Config} List property: {@value #R_NOMINAL_FIELDS}<br>


### PR DESCRIPTION

Refactor download utility to use rsync
  + Using rsync, the file structure is maintained when downlaoded
  + Use downloadList.txt file at project root to direct rsync download
  + Display file size in editable download list.
  + Preserve file mod times in download transfer
  + Remove scpExtensions method (all R modules)
  + Change script name from blj_scp to blj_download.